### PR TITLE
Add support for loading CoffeeScript plugins.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -29,9 +29,25 @@ const zip = function () {
 
 const errors = require('./errors.js');
 
+const hasCoffee = (function() {
+    try {
+        require('coffee-script/register');
+        return true;
+    } catch(e) {
+        return false;
+    }
+})();
+
 module.exports = function PluginLoader (pluginSystem, fs, require, systemname) {
-    function exists (path) {
-        return fs.existsSync(path + ".js") || fs.existsSync(path);
+    var exists;
+    if (hasCoffee) {
+        exists = function(path) {
+            return fs.existsSync(path + ".js") || fs.existsSync(path + ".coffee")  || fs.existsSync(path);
+        }
+    } else {
+        exists = function (path) {
+            return fs.existsSync(path + ".js") || fs.existsSync(path);
+        }
     }
 
     function use (_names, path) {


### PR DESCRIPTION
This tests if the user has CoffeeScript installed, registers it, so `require` can handle it automatically and modifies the `exists` function so that it also checks for `.coffee` files if the user indeed has CoffeeScript.
